### PR TITLE
Fix use of indices for nested json info retrieval for json path filters

### DIFF
--- a/src/BatchJobsStates/JobStatesStateMachineServerless.asl.json
+++ b/src/BatchJobsStates/JobStatesStateMachineServerless.asl.json
@@ -76,10 +76,18 @@
           "Variable": "$$.Execution.Input.detail.container.containerInstanceArn",
           "IsPresent": true,
           "Next": "Get ContainerInstanceId from containerInstanceArn"
-        },{
-          "Variable": "$$.Execution.Input.detail.attempts[0].container.containerInstanceArn",
+        }
+      ],
+      "Default": "Get Job State for Instance Association Array"
+    },
+    "Get Job State for Instance Association Array": {
+      "Type": "Choice",
+      "InputPath": "$$.Execution.Input.detail.attempts[-1]",
+      "Choices": [
+        {
+          "Variable": "$.container.containerInstanceArn",
           "IsPresent": true,
-          "Next": "Get ContainerInstanceId from attempts[0].container.containerInstanceArn"
+          "Next": "Get ContainerInstanceId from attempts[-1].container.containerInstanceArn"
         }
       ],
       "Default": "Skip Event"
@@ -90,10 +98,10 @@
       "InputPath": "$$.Execution.Input.detail.container.containerInstanceArn",
       "ResultPath": "$.containerInstanceArn"
     },
-    "Get ContainerInstanceId from attempts[0].container.containerInstanceArn": {
+    "Get ContainerInstanceId from attempts[-1].container.containerInstanceArn": {
       "Type": "Pass",
       "Next": "DynamoDB GetItem EC2 InstanceId from ContainerInstanceId",
-      "InputPath": "$$.Execution.Input.detail.attempts[0].container.containerInstanceArn",
+      "InputPath": "$$.Execution.Input.detail.attempts[-1].container.containerInstanceArn",
       "ResultPath": "$.containerInstanceArn"
     },
     "DynamoDB GetItem EC2 InstanceId from ContainerInstanceId": {

--- a/src/ECSInstancesRegistration/ECSInstancesRegistrationStateMachineServerless.asl.json
+++ b/src/ECSInstancesRegistration/ECSInstancesRegistrationStateMachineServerless.asl.json
@@ -9,14 +9,26 @@
                     "Variable": "$.detail.errorCode",
                     "IsPresent": true
                 },
-                "Next": "DynamoDB PutItem"
+                "Next": "Get Fields DDB"
             }],
             "Default": "Success"
+        },
+        "Get Fields DDB": {
+            "Type": "Pass",
+            "Next": "DynamoDB PutItem",
+            "Comment": "Filter the elements using json path",
+            "Parameters": {
+                "detail.$": "$.detail",
+                "AvailabilityZone.$": "$.detail.responseElements.containerInstance.attributes[?(@.name==ecs.availability-zone)].value",
+                "InstanceType.$": "$.detail.responseElements.containerInstance.attributes[?(@.name==ecs.instance-type)].value",
+                "AmiId.$": "$.detail.responseElements.containerInstance.attributes[?(@.name==ecs.ami-id)].value",
+                "CPU.$": "$.detail.responseElements.containerInstance.registeredResources[?(@.name==CPU)].integerValue",
+                "Memory.$": "$.detail.responseElements.containerInstance.registeredResources[?(@.name==MEMORY)].integerValue"
+            }
         },
         "DynamoDB PutItem": {
             "Type": "Task",
             "Resource": "arn:aws:states:::dynamodb:putItem",
-            "InputPath": "$$.Execution.Input",
             "Parameters": {
                 "TableName": "${ECSRegistrationTable}",
                 "ConditionExpression": "attribute_not_exists(ContainerInstanceId)",
@@ -37,19 +49,19 @@
                         "S.$": "$.detail.requestParameters.cluster"
                     },
                     "AvailabilityZone": {
-                        "S.$": "$.detail.responseElements.containerInstance.attributes[15].value"
+                        "S.$": "$.AvailabilityZone[0]"
                     },
                     "InstanceType": {
-                        "S.$": "$.detail.responseElements.containerInstance.attributes[53].value"
+                        "S.$": "$.InstanceType[0]"
                     },
                     "AmiId": {
-                        "S.$": "$.detail.responseElements.containerInstance.attributes[2].value"
+                        "S.$": "$.AmiId[0]"
                     },
                     "CPU": {
-                        "N.$": "States.Format('{}',$.detail.responseElements.containerInstance.registeredResources[0].integerValue)"
+                        "N.$": "States.Format('{}',$.CPU[0])"
                     },
                     "Memory": {
-                        "N.$": "States.Format('{}',$.detail.responseElements.containerInstance.registeredResources[1].integerValue)"
+                        "N.$": "States.Format('{}',$.Memory[0])"
                     },
                     "Events": {
                         "L": [{
@@ -65,7 +77,7 @@
                     }
                 }
             },
-            "Next": "SQS SendMessage",
+            "Next": "Get Fields SQS",
             "Catch": [{
                 "ErrorEquals": ["DynamoDB.ConditionalCheckFailedException"],
                 "Next": "DynamoDB UpdateItem",
@@ -105,42 +117,54 @@
                     }
                 }
             },
-            "Retry": [ {
-                "ErrorEquals": [ "States.ALL"  ],
+            "Retry": [{
+                "ErrorEquals": ["States.ALL"],
                 "IntervalSeconds": 1,
                 "BackoffRate": 2.0,
                 "MaxAttempts": 10
-                } ],
-            "Next": "SQS SendMessage"
+            }],
+            "Next": "Get Fields SQS"
+        },
+        "Get Fields SQS": {
+            "Type": "Pass",
+            "Next": "SQS SendMessage",
+            "Comment": "Filter the elements using json path",
+            "Parameters": {
+                "detail.$": "$$.Execution.Input.detail",
+                "AvailabilityZone.$": "$$.Execution.Input.detail.responseElements.containerInstance.attributes[?(@.name==ecs.availability-zone)].value",
+                "InstanceType.$": "$$.Execution.Input.detail.responseElements.containerInstance.attributes[?(@.name==ecs.instance-type)].value",
+                "AmiId.$": "$$.Execution.Input.detail.responseElements.containerInstance.attributes[?(@.name==ecs.ami-id)].value",
+                "CPU.$": "$$.Execution.Input.detail.responseElements.containerInstance.registeredResources[?(@.name==CPU)].integerValue",
+                "Memory.$": "$$.Execution.Input.detail.responseElements.containerInstance.registeredResources[?(@.name==MEMORY)].integerValue"
+            }
         },
         "SQS SendMessage": {
             "Type": "Task",
             "Resource": "arn:aws:states:::sqs:sendMessage",
-            "InputPath": "$$.Execution.Input",
             "Parameters": {
                 "QueueUrl": "${SQSMetricsQueue}",
                 "MessageBody": {
                     "Dimensions": {
-                        "AvailabilityZone.$": "$.detail.responseElements.containerInstance.attributes[15].value",
+                        "AvailabilityZone.$": "$.AvailabilityZone[0]",
                         "ECSCluster.$": "$.detail.requestParameters.cluster",
-                        "InstanceType.$": "$.detail.responseElements.containerInstance.attributes[53].value"
+                        "InstanceType.$": "$.InstanceType[0]"
                     },
                     "Properties": {
                         "InstanceId.$": "$.detail.responseElements.containerInstance.ec2InstanceId",
                         "ECSCluster.$": "$.detail.requestParameters.cluster",
-                        "InstanceType.$": "$.detail.responseElements.containerInstance.attributes[53].value",
-                        "AvailabilityZone.$": "$.detail.responseElements.containerInstance.attributes[15].value"
+                        "InstanceType.$": "$.InstanceType[0]",
+                        "AvailabilityZone.$": "$.AvailabilityZone[0]"
                     },
                     "LastEventType.$": "$.detail.eventName",
                     "MetricTime.$": "$.detail.eventTime"
                 }
             },
-            "Retry": [ {
-                "ErrorEquals": [ "States.ALL"  ],
+            "Retry": [{
+                "ErrorEquals": ["States.ALL"],
                 "IntervalSeconds": 1,
                 "BackoffRate": 2.0,
                 "MaxAttempts": 10
-                } ],
+            }],
             "Next": "Success"
         },
         "Success": {

--- a/src/ECSRunTask/ECSRunTaskStateMachineServerless.asl.json
+++ b/src/ECSRunTask/ECSRunTaskStateMachineServerless.asl.json
@@ -21,10 +21,10 @@
             "Parameters": {
                 "Region.$": "$.detail.awsRegion",
                 "LastEventTime.$": "$.detail.eventTime",
-                "JobId.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[0].value",
-                "CEName.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[2].value",
-                "JQName.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[1].value",
-                "JobAttempt.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[3].value",
+                "JobId.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name==AWS_BATCH_JOB_ID)].value",
+                "CEName.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name==AWS_BATCH_CE_NAME)].value",
+                "JQName.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name==AWS_BATCH_JQ_NAME)].value",
+                "JobAttempt.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name==AWS_BATCH_JOB_ATTEMPT)].value",
                 "ECSCluster.$": "$.detail.requestParameters.cluster"
             }
         },
@@ -36,15 +36,15 @@
                 "QueueUrl": "${SQSMetricsQueue}",
                 "MessageBody": {
                     "Dimensions": {
-                        "JobQueue.$": "$.JQName",
+                        "JobQueue.$": "$.JQName[0]",
                         "ECSCluster.$": "$.ECSCluster",
-                        "ComputeEnvironment.$": "$.CEName"
+                        "ComputeEnvironment.$": "$.CEName[0]"
                     },
                     "Properties": {
-                        "JobId.$": "$.JobId",
+                        "JobId.$": "$.JobId[0]",
                         "ECSCluster.$": "$.ECSCluster",
-                        "JobQueue.$": "$.JQName",
-                        "ComputeEnvironment.$": "$.CEName"
+                        "JobQueue.$": "$.JQName[0]",
+                        "ComputeEnvironment.$": "$.CEName[0]"
                     },
                     "MetricName": "RunTask Call",
                     "MetricTime.$": "$.LastEventTime"
@@ -61,20 +61,15 @@
         "Is Array Job?": {
             "Type": "Choice",
             "Choices": [{
-                "And": [{
-                    "Variable": "$$.Execution.Input.detail.requestParameters.overrides.containerOverrides[0].environment[4]",
-                    "IsPresent": true
-                }, {
-                    "Variable": "$$.Execution.Input.detail.requestParameters.overrides.containerOverrides[0].environment[4].name",
-                    "StringEquals": "AWS_BATCH_JOB_ARRAY_INDEX"
-                }],
+                "Variable": "$$.Execution.Input.detail.requestParameters.overrides.containerOverrides[0].environment[4]",
+                 "IsPresent": true,
                 "Next": "Yes, add job index"
             }],
             "Default": "Is task placed onto an instance?"
         },
         "Yes, add job index": {
             "Type": "Pass",
-            "InputPath": "$$.Execution.Input.detail.requestParameters.overrides.containerOverrides[0].environment[4].value",
+            "InputPath": "$$.Execution.Input.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name==AWS_BATCH_JOB_ARRAY_INDEX)].value",
             "ResultPath": "$.JobArrayIndex",
             "Next": "Is task placed onto an instance?"
         },
@@ -154,9 +149,9 @@
                 "QueueUrl": "${SQSMetricsQueue}",
                 "MessageBody": {
                     "Dimensions": {
-                        "JobQueue.$": "$.JQName",
+                        "JobQueue.$": "$.JQName[0]",
                         "ECSCluster.$": "$.ECSCluster",
-                        "ComputeEnvironment.$": "$.CEName",
+                        "ComputeEnvironment.$": "$.CEName[0]",
                         "AvailabilityZone.$": "$.AvailabilityZone",
                         "InstanceType.$": "$.InstanceProperties.Item.InstanceType.S"
                     },
@@ -164,8 +159,8 @@
                         "JobId.$": "$.JobId",
                         "InstanceId.$": "$.InstanceProperties.Item.InstanceId.S",
                         "ECSCluster.$": "$.ECSCluster",
-                        "JobQueue.$": "$.JQName",
-                        "ComputeEnvironment.$": "$.CEName",
+                        "JobQueue.$": "$.JQName[0]",
+                        "ComputeEnvironment.$": "$.CEName[0]",
                         "AvailabilityZone.$": "$.AvailabilityZone",
                         "InstanceType.$": "$.InstanceProperties.Item.InstanceType.S"
                     },


### PR DESCRIPTION
Fix #2 by moving the use of indices for retrieval in favor of json path filters. Transient `Pass` states have been added to allow the conversion of lists generated by json path filters to a single element.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
