### PR TITLE
Add Job Definition tracking in metrics dashboards

### DIFF
--- a/src/BatchJobsStates/JobStatesStateMachineServerless.asl.json
+++ b/src/BatchJobsStates/JobStatesStateMachineServerless.asl.json
@@ -10,6 +10,7 @@
         "Region.$": "$.region",
         "JobQueue.$": "$.detail.jobQueue",
         "JobName.$": "$.detail.jobName",
+        "JobDefinition.$": "$.detail.jobDefinition",
         "LastEventType.$": "$.detail.status",
         "LastEventTime.$": "$.time"
       }
@@ -151,7 +152,8 @@
             "JobState.$": "$.LastEventType",
             "AvailabilityZone.$": "$.ECSInstance.Item.AvailabilityZone.S",
             "ECSCluster.$": "$.ECSInstance.Item.ECSCluster.S",
-            "InstanceType.$": "$.ECSInstance.Item.InstanceType.S"
+            "InstanceType.$": "$.ECSInstance.Item.InstanceType.S",
+            "JobDefinition.$":"$.JobDefinition"
           },
           "Properties": {
             "JobId.$": "$.JobId",
@@ -161,7 +163,8 @@
             "ECSCluster.$": "$.ECSInstance.Item.ECSCluster.S",
             "InstanceType.$": "$.ECSInstance.Item.InstanceType.S",
             "InstanceId.$": "$.ECSInstance.Item.InstanceId.S",
-            "JobName.$": "$.JobName"
+            "JobName.$": "$.JobName",
+            "JobDefinition.$":"$.JobDefinition"
           },
           "MetricName.$": "$.LastEventType",
           "MetricTime.$": "$.LastEventTime"
@@ -183,13 +186,15 @@
         "MessageBody": {
           "Dimensions": {
             "JobQueue.$": "$.JobQueue",
-            "JobState.$": "$.LastEventType"
+            "JobState.$": "$.LastEventType",
+            "JobDefinition.$":"$.JobDefinition"
           },
           "Properties": {
             "JobId.$": "$.JobId",
             "JobQueue.$": "$.JobQueue",
             "JobState.$": "$.LastEventType",
-            "JobName.$": "$.JobName"
+            "JobName.$": "$.JobName",
+            "JobDefinition.$":"$.JobDefinition"
           },
           "MetricName.$": "$.LastEventType",
           "MetricTime.$": "$.LastEventTime"

--- a/src/BatchJobsStates/JobStatesToCW/app.py
+++ b/src/BatchJobsStates/JobStatesToCW/app.py
@@ -51,7 +51,6 @@ def embedded_metrics_placed_jobs(dimensions, properties, metric_name, metric_tim
         raise Exception(message)
     return
 
-
 def lambda_handler(event, context):
 
     logger.info(f"Transform event to metric {json.dumps(event)}")
@@ -74,6 +73,14 @@ def lambda_handler(event, context):
         if 'JobQueue' in rec['Dimensions']:
             job_queue = rec['Dimensions']['JobQueue'].split('/')[-1]
             rec['Dimensions']['JobQueue'] = job_queue
+
+        if 'JobDefinition' in rec['Properties']:
+            job_queue = rec['Properties']['JobDefinition'].split('/')[-1]
+            rec['Properties']['JobDefinition'] = job_queue
+
+        if 'JobDefinition' in rec['Dimensions']:
+            job_queue = rec['Dimensions']['JobDefinition'].split('/')[-1]
+            rec['Dimensions']['JobDefinition'] = job_queue
 
         embedded_metrics_placed_jobs(
             rec["Dimensions"],

--- a/template.yaml
+++ b/template.yaml
@@ -1043,7 +1043,7 @@ Resources:
                         "height": 6,
                         "width": 6,
                         "y": 34,
-                        "x": 0,
+                        "x": 12,
                         "type": "metric",
                         "properties": {
                             "metrics": [
@@ -1097,9 +1097,9 @@ Resources:
                     },
                     {
                         "height": 6,
-                        "width": 6,
+                        "width": 12,
                         "y": 34,
-                        "x": 6,
+                        "x": 0,
                         "type": "metric",
                         "properties": {
                             "metrics": [
@@ -1127,7 +1127,7 @@ Resources:
                         "height": 6,
                         "width": 6,
                         "y": 34,
-                        "x": 12,
+                        "x": 18,
                         "type": "metric",
                         "properties": {
                             "metrics": [
@@ -1195,6 +1195,184 @@ Resources:
                             "stacked": true,
                             "region": "${DeployedRegion}",
                             "title": "Jobs FAILED - Job Queue",
+                            "yAxis": {
+                                "left": {
+                                    "label": "Jobs",
+                                    "showUnits": false
+                                },
+                                "right": {
+                                    "showUnits": false
+                                }
+                            },
+                            "liveData": true
+                        }
+                    },
+                    {
+                        "height": 6,
+                        "width": 12,
+                        "y": 41,
+                        "x": 0,
+                        "type": "metric",
+                        "properties": {
+                            "metrics": [
+                                [ { "expression": "SEARCH('{AWSBatchMetrics,JobDefinition} MetricName=\"RUNNING\"', 'Sum', 60)", "id": "e5" } ]
+                            ],
+                            "period": 60,
+                            "stat": "Sum",
+                            "view": "timeSeries",
+                            "stacked": true,
+                            "region": "${DeployedRegion}",
+                            "title": "RUNNING - Job Definition",
+                            "yAxis": {
+                                "left": {
+                                    "label": "Jobs",
+                                    "showUnits": false
+                                },
+                                "right": {
+                                    "showUnits": false
+                                }
+                            },
+                            "liveData": true
+                        }
+                    },
+                    {
+                        "height": 1,
+                        "width": 24,
+                        "y": 40,
+                        "x": 0,
+                        "type": "text",
+                        "properties": {
+                            "markdown": "# Jobs States per Job Definition\n"
+                        }
+                    },
+                    {
+                        "height": 6,
+                        "width": 6,
+                        "y": 41,
+                        "x": 12,
+                        "type": "metric",
+                        "properties": {
+                            "metrics": [
+                                [ { "expression": "SEARCH('{AWSBatchMetrics,JobDefinition} MetricName=\"SUCCEEDED\"', 'Sum', 60)", "id": "e5" } ]
+                            ],
+                            "period": 60,
+                            "stat": "Sum",
+                            "view": "timeSeries",
+                            "stacked": true,
+                            "region": "${DeployedRegion}",
+                            "title": "SUCCEEDED - Job Definition",
+                            "yAxis": {
+                                "left": {
+                                    "label": "Jobs",
+                                    "showUnits": false
+                                },
+                                "right": {
+                                    "showUnits": false
+                                }
+                            },
+                            "liveData": true
+                        }
+                    },
+                    {
+                        "height": 6,
+                        "width": 6,
+                        "y": 41,
+                        "x": 18,
+                        "type": "metric",
+                        "properties": {
+                            "metrics": [
+                                [ { "expression": "SEARCH('{AWSBatchMetrics,JobDefinition} MetricName=\"FAILED\"', 'Sum', 60)", "id": "e5" } ]
+                            ],
+                            "period": 60,
+                            "stat": "Sum",
+                            "view": "timeSeries",
+                            "stacked": true,
+                            "region": "${DeployedRegion}",
+                            "title": "FAILED - Job Definition",
+                            "yAxis": {
+                                "left": {
+                                    "label": "Jobs",
+                                    "showUnits": false
+                                },
+                                "right": {
+                                    "showUnits": false
+                                }
+                            },
+                            "liveData": true
+                        }
+                    },
+                    {
+                        "height": 6,
+                        "width": 6,
+                        "y": 47,
+                        "x": 18,
+                        "type": "metric",
+                        "properties": {
+                            "metrics": [
+                                [ { "expression": "SEARCH('{AWSBatchMetrics,JobDefinition} MetricName=\"STARTING\"', 'Sum', 60)", "id": "e5" } ]
+                            ],
+                            "period": 60,
+                            "stat": "Sum",
+                            "view": "timeSeries",
+                            "stacked": true,
+                            "region": "${DeployedRegion}",
+                            "title": "STARTING - Job Definition",
+                            "yAxis": {
+                                "left": {
+                                    "label": "Jobs",
+                                    "showUnits": false
+                                },
+                                "right": {
+                                    "showUnits": false
+                                }
+                            },
+                            "liveData": true
+                        }
+                    },
+                    {
+                        "height": 6,
+                        "width": 12,
+                        "y": 47,
+                        "x": 0,
+                        "type": "metric",
+                        "properties": {
+                            "metrics": [
+                                [ { "expression": "SEARCH('{AWSBatchMetrics,JobDefinition} MetricName=\"RUNNABLE\"', 'Sum', 60)", "id": "e5" } ]
+                            ],
+                            "period": 60,
+                            "stat": "Sum",
+                            "view": "timeSeries",
+                            "stacked": true,
+                            "region": "${DeployedRegion}",
+                            "title": "RUNNABLE - Job Definition",
+                            "yAxis": {
+                                "left": {
+                                    "label": "Jobs",
+                                    "showUnits": false
+                                },
+                                "right": {
+                                    "showUnits": false
+                                }
+                            },
+                            "liveData": true
+                        }
+                    },
+                    {
+                        "height": 6,
+                        "width": 6,
+                        "y": 47,
+                        "x": 12,
+                        "type": "metric",
+                        "properties": {
+                            "metrics": [
+                                [ { "expression": "SEARCH('{AWSBatchMetrics,JobDefinition} MetricName=\"PENDING\"', 'Sum', 60)", "id": "e5" } ]
+                            ],
+                            "period": 60,
+                            "stat": "Sum",
+                            "view": "timeSeries",
+                            "stacked": true,
+                            "region": "${DeployedRegion}",
+                            "title": "PENDING - Job Definition",
                             "yAxis": {
                                 "left": {
                                     "label": "Jobs",


### PR DESCRIPTION
Original change proposed by @psantora-amazon

*Issue #, if available:* #4

*Description of changes:* Adds Job Definition metrics and widgets in the Job States dashboard.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
