### PR TITLE
Fix json path syntax in filter expression #6

### DIFF
--- a/src/ECSInstancesRegistration/ECSInstancesRegistrationStateMachineServerless.asl.json
+++ b/src/ECSInstancesRegistration/ECSInstancesRegistrationStateMachineServerless.asl.json
@@ -19,11 +19,11 @@
             "Comment": "Filter the elements using json path",
             "Parameters": {
                 "detail.$": "$.detail",
-                "AvailabilityZone.$": "$.detail.responseElements.containerInstance.attributes[?(@.name==ecs.availability-zone)].value",
-                "InstanceType.$": "$.detail.responseElements.containerInstance.attributes[?(@.name==ecs.instance-type)].value",
-                "AmiId.$": "$.detail.responseElements.containerInstance.attributes[?(@.name==ecs.ami-id)].value",
-                "CPU.$": "$.detail.responseElements.containerInstance.registeredResources[?(@.name==CPU)].integerValue",
-                "Memory.$": "$.detail.responseElements.containerInstance.registeredResources[?(@.name==MEMORY)].integerValue"
+                "AvailabilityZone.$": "$.detail.responseElements.containerInstance.attributes[?(@.name=='ecs.availability-zone')].value",
+                "InstanceType.$": "$.detail.responseElements.containerInstance.attributes[?(@.name=='ecs.instance-type')].value",
+                "AmiId.$": "$.detail.responseElements.containerInstance.attributes[?(@.name=='ecs.ami-id')].value",
+                "CPU.$": "$.detail.responseElements.containerInstance.registeredResources[?(@.name=='CPU')].integerValue",
+                "Memory.$": "$.detail.responseElements.containerInstance.registeredResources[?(@.name=='MEMORY')].integerValue"
             }
         },
         "DynamoDB PutItem": {
@@ -131,11 +131,11 @@
             "Comment": "Filter the elements using json path",
             "Parameters": {
                 "detail.$": "$$.Execution.Input.detail",
-                "AvailabilityZone.$": "$$.Execution.Input.detail.responseElements.containerInstance.attributes[?(@.name==ecs.availability-zone)].value",
-                "InstanceType.$": "$$.Execution.Input.detail.responseElements.containerInstance.attributes[?(@.name==ecs.instance-type)].value",
-                "AmiId.$": "$$.Execution.Input.detail.responseElements.containerInstance.attributes[?(@.name==ecs.ami-id)].value",
-                "CPU.$": "$$.Execution.Input.detail.responseElements.containerInstance.registeredResources[?(@.name==CPU)].integerValue",
-                "Memory.$": "$$.Execution.Input.detail.responseElements.containerInstance.registeredResources[?(@.name==MEMORY)].integerValue"
+                "AvailabilityZone.$": "$$.Execution.Input.detail.responseElements.containerInstance.attributes[?(@.name=='ecs.availability-zone')].value",
+                "InstanceType.$": "$$.Execution.Input.detail.responseElements.containerInstance.attributes[?(@.name=='ecs.instance-type')].value",
+                "AmiId.$": "$$.Execution.Input.detail.responseElements.containerInstance.attributes[?(@.name=='ecs.ami-id')].value",
+                "CPU.$": "$$.Execution.Input.detail.responseElements.containerInstance.registeredResources[?(@.name=='CPU')].integerValue",
+                "Memory.$": "$$.Execution.Input.detail.responseElements.containerInstance.registeredResources[?(@.name=='MEMORY')].integerValue"
             }
         },
         "SQS SendMessage": {

--- a/src/ECSRunTask/ECSRunTaskStateMachineServerless.asl.json
+++ b/src/ECSRunTask/ECSRunTaskStateMachineServerless.asl.json
@@ -21,10 +21,10 @@
             "Parameters": {
                 "Region.$": "$.detail.awsRegion",
                 "LastEventTime.$": "$.detail.eventTime",
-                "JobId.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name==AWS_BATCH_JOB_ID)].value",
-                "CEName.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name==AWS_BATCH_CE_NAME)].value",
-                "JQName.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name==AWS_BATCH_JQ_NAME)].value",
-                "JobAttempt.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name==AWS_BATCH_JOB_ATTEMPT)].value",
+                "JobId.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name=='AWS_BATCH_JOB_ID')].value",
+                "CEName.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name=='AWS_BATCH_CE_NAME')].value",
+                "JQName.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name=='AWS_BATCH_JQ_NAME')].value",
+                "JobAttempt.$": "$.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name=='AWS_BATCH_JOB_ATTEMPT')].value",
                 "ECSCluster.$": "$.detail.requestParameters.cluster"
             }
         },
@@ -69,7 +69,7 @@
         },
         "Yes, add job index": {
             "Type": "Pass",
-            "InputPath": "$$.Execution.Input.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name==AWS_BATCH_JOB_ARRAY_INDEX)].value",
+            "InputPath": "$$.Execution.Input.detail.requestParameters.overrides.containerOverrides[0].environment[?(@.name=='AWS_BATCH_JOB_ARRAY_INDEX')].value",
             "ResultPath": "$.JobArrayIndex",
             "Next": "Is task placed onto an instance?"
         },


### PR DESCRIPTION
*Issue #, if available:* #6 

*Description of changes:* The filter expression was missing simple quotes around the searched strings. This would lead to failed states in the state machines but not systematically. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
