### PR TITLE
Updates to fix deprecated options in docs/ExamplesCfnTemplates/Batch-…

### DIFF
--- a/docs/ExamplesCfnTemplates/Batch-Large-Scale.yaml
+++ b/docs/ExamplesCfnTemplates/Batch-Large-Scale.yaml
@@ -117,8 +117,11 @@ Resources:
           - --cpu-load
           - 100
         Image: !Join ['', [!Ref 'AWS::AccountId','.dkr.ecr.', !Ref 'AWS::Region', '.amazonaws.com/', !Ref StressRepository ] ]
-        Vcpus: 2
-        Memory: 3192
+        ResourceRequirements:
+          - Type: MEMORY
+            Value: '3192'
+          - Type: VCPU
+            Value: '2'
       PropagateTags: true
       RetryStrategy:
         Attempts: 10


### PR DESCRIPTION
…Large-Scale.yaml.

*Issue #, if available:*

Existing VCPUS and MEMORY specification in Job Definition ContainerProperties uses options that are now deprecated.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html

*Description of changes:*
Move these into ResourceRequirements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
